### PR TITLE
Fix HAL name typo

### DIFF
--- a/vintf/device_framework_matrix.xml
+++ b/vintf/device_framework_matrix.xml
@@ -73,7 +73,7 @@
     <hal format="aidl" optional="true">
         <name>vendor.oplus.hardware.camera.aon</name>
         <interface>
-            <name>IAONServi1ce</name>
+            <name>IAONService</name>
             <instance>default</instance>
         </interface>
     </hal>
@@ -120,7 +120,7 @@
         <name>vendor.oplus.hardware.camera.aon</name>
         <version>1</version>
         <interface>
-            <name>IAONServi1ce</name>
+            <name>IAONService</name>
             <instance>default</instance>
         </interface>
     </hal>


### PR DESCRIPTION
## Summary
- fix IAONService interface name in `vintf/device_framework_matrix.xml`

## Testing
- `xmllint --noout vintf/device_framework_matrix.xml`


------
https://chatgpt.com/codex/tasks/task_e_68406979264c83328b22d07aa368d524